### PR TITLE
alxLogger - check all read parameters when determining if metadata needs to be modified

### DIFF
--- a/alxLogger.c
+++ b/alxLogger.c
@@ -1581,7 +1581,9 @@ static Alx_Status AlxLogger_CheckRepairWriteFile(AlxLogger* me)
 		// In this case they must be synchronized otherwise read.pos could point into a middle of log
 		if ((me->md.read.dir == me->md.write.dir) &&
 			(me->md.read.file == me->md.write.file) &&
-			(me->md.read.pos > me->md.write.pos))
+			((me->md.read.pos > me->md.write.pos) ||
+			 (me->md.read.log > me->md.write.log) ||
+			 (me->md.read.id > me->md.write.id)))
 		{
 			me->md.read.pos = me->md.write.pos;
 			me->md.read.log = me->md.write.log;


### PR DESCRIPTION
During testing we found a device where read.log and read.pos were ok, but read.id was too high and inconsistent with other data. This fix ensures such cases are caught and fixed.