### PR TITLE
alxLogger - fixed edge case where write pointer is already wrapped, but read pointer is not

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
 # Auralix C Library
-- Current Version - [v0.19.2](https://github.com/auralix/alx-202-af-10-1-auralix-c-lib/tree/v0.19.2)
+- Current Version - [v0.19.3](https://github.com/auralix/alx-202-af-10-1-auralix-c-lib/tree/v0.19.3)

--- a/alxLogger.c
+++ b/alxLogger.c
@@ -1532,6 +1532,18 @@ static Alx_Status AlxLogger_CheckRepairReadFile(AlxLogger* me)
 
 	// Ensure read.id is consistent with read.dir, .file and .log
 	uint64_t loggerRotations = (me->md.oldest.id + (me->numOfLogsTotal - 1)) / me->numOfLogsTotal;
+	if (loggerRotations != 0)
+	{
+		if ((me->md.oldest.id % me->numOfLogsTotal) == 0)
+		{
+			loggerRotations++;
+		}
+		if (me->md.read.dir >= me->md.oldest.dir)
+		{
+			// This will happen if write is already wrapped but read is not - read has one fewer logger rotation
+			loggerRotations--;
+		}
+	}
 	uint64_t expectedId = me->md.read.dir * me->md.numOfFilesPerDir * me->md.numOfLogsPerFile
 		+ me->md.read.file * me->md.numOfLogsPerFile
 		+ me->md.read.log;


### PR DESCRIPTION
When checking read metadata on boot number of logger rotations could be calculated incorrectly which lead to metadata corruption and logger format or read assert. This commit fixes logger rotations calculation by including problematic edge cases.